### PR TITLE
Fix issue with build and deploy

### DIFF
--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -21,7 +21,9 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-latest
+    # 2024-10-01: ubuntu-latest is now 24.04 and R is not installed by default in the runner image
+    # pin to 22.04 for now
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       contents: write


### PR DESCRIPTION
Ubuntu 24 comes with no R installed, fix issues with GH action by pinning Ubuntu 22.

Applying this fix: https://github.com/carpentries/sandpaper/pull/606/files

See issue: https://github.com/carpentries/sandpaper/issues/605